### PR TITLE
Add extras field to HorizonError

### DIFF
--- a/src/horizon_error.rs
+++ b/src/horizon_error.rs
@@ -1,6 +1,26 @@
 //! Horizon error response.
 use serde::{Deserialize, Serialize};
 
+/// Result codes for individual operations related to horizon error response
+#[derive(Debug, Clone, Deserialize, Serialize)]
+pub struct HorizonErrorExtrasResultCodes {
+    /// The transaction Result Code returned by Stellar Core, which can be used to look up more information about an error in the docs.
+    pub transaction: String,
+    /// An array of operation Result Codes returned by Stellar Core, which can be used to look up more information about an error in the docs.
+    pub operations: Vec<String>,
+}
+
+/// Extra information related to horizon error response
+#[derive(Debug, Clone, Deserialize, Serialize)]
+pub struct HorizonErrorExtras {
+    /// A base64-encoded representation of the TransactionEnvelope XDR whose failure triggered this response.
+    pub envelope_xdr: String,
+    /// A base64-encoded representation of the TransactionResult XDR returned by stellar-core when submitting this transaction.
+    pub result_xdr: String,
+    /// Result codes for the individual operations
+    pub result_codes: HorizonErrorExtrasResultCodes,
+}
+
 /// Horizon error response.
 #[derive(Debug, Clone, Deserialize, Serialize)]
 pub struct HorizonError {
@@ -10,4 +30,6 @@ pub struct HorizonError {
     pub detail: String,
     /// The status code.
     pub status: i64,
+    /// If the Status Code is Transaction Failed, this extras field displays the Result Code returned by Stellar Core describing why the transaction failed.
+    pub extras: Option<HorizonErrorExtras>,
 }


### PR DESCRIPTION
The extras field contains important information regarding errors
returned from the horizon server.  Although truely useful during
debugging, it can also be helpful when creating error messages
in client applications.

This change adds the extars field as an Option, thus not breaking
decoding if the extras field is not included in the response.

Example data returned before the change:
```
    HorizonRequestError(
        HorizonError {
            title: "Transaction Failed",
            detail: "The transaction failed when submitted to the stellar network. The `extras.result_codes` field on this response contains further details.  Descriptions of each code can be found at: https://www.stellar.org/developers/guides/concepts/list-of-operations.html",
        },
    )
```

Example data returned after the change:
```
    HorizonRequestError(
        HorizonError {
            title: "Transaction Failed",
            detail: "The transaction failed when submitted to the stellar network. The `extras.result_codes` field on this response contains further details.  Descriptions of each code can be found at: https://www.stellar.org/developers/guides/concepts/list-of-operations.html",
            status: 400,
            extras: Some(
                HorizonErrorExtras {
                    envelope_xdr: "AAAAAgAAAAB1u6Vb0xjXUKbnStYZta6jKVSX/u16qvwURvW6phRG5AAAAGQAEHG+AAAAAwAAAAAAAAAAAAAAAQAAAAAAAAAAAAAAAE9NdrcgB/zxT1rFTzqhFNabynkPgj9jictRtrEOuKg/AAAAAAAAA+gAAAAAAAAAAaYURuQAAABAp9MQfZ2gogoezs/pdmJu9oYnsdlHJ779zOgHAdYcm+CQ9rkeeNbxfNnFePbbPg+O5lDFYI4cUsPMV1HyBXr/Bg==",
                    result_xdr: "AAAAAAAAAGT/////AAAAAQAAAAAAAAAA/////QAAAAA=",
                    result_codes: HorizonErrorExtrasResultCodes {
                        transaction: "tx_failed",
                        operations: [
                            "op_low_reserve",
                        ],
                    },
                },
            ),
        },
    )
```