### PR TITLE
Deserialize horizon error response

### DIFF
--- a/.github/workflows/coverage.yml
+++ b/.github/workflows/coverage.yml
@@ -26,6 +26,6 @@ jobs:
           SECRET_SEED: ${{ secrets.SECRET_SEED }}
 
       - name: Upload to codecov.io
-        uses: codecov/codecov-action@v1.0.2
+        uses: codecov/codecov-action@v1
         with:
           token: ${{secrets.CODECOV_TOKEN}}

--- a/src/horizon_error.rs
+++ b/src/horizon_error.rs
@@ -1,13 +1,155 @@
 //! Horizon error response.
 use serde::{Deserialize, Serialize};
 
+const BAD_REQUEST_TYPE: &str = "https://stellar.org/horizon-errors/bad_request";
+const TRANSACTION_FAILED_TYPE: &str = "https://stellar.org/horizon-errors/transaction_failed";
+const TRANSACTION_MALFORMED_TYPE: &str = "https://stellar.org/horizon-errors/transaction_malformed";
+const BEFORE_HISTORY_TYPE: &str = "https://stellar.org/horizon-errors/before_history";
+const STALE_HISTORY_TYPE: &str = "https://stellar.org/horizon-errors/stale_history";
+const TIMEOUT_TYPE: &str = "https://stellar.org/horizon-errors/timeout";
+
 /// Horizon error response.
-#[derive(Debug, Clone, Deserialize, Serialize)]
-pub struct HorizonError {
+#[derive(Debug, Clone, PartialEq)]
+pub enum HorizonError {
+    BadRequest(HorizonErrorBadRequest),
+    TransactionFailed(HorizonErrorTransactionFailed),
+    TransactionMalformed(HorizonErrorTransactionMalformed),
+    BeforeHistory(HorizonErrorBase),
+    StaleHistory(HorizonErrorBase),
+    Timeout(HorizonErrorBase),
+    Other(HorizonErrorBase),
+}
+
+/// Common fields in horizon error responses.
+#[derive(Debug, Clone, PartialEq, Deserialize, Serialize)]
+pub struct HorizonErrorBase {
+    #[serde(rename = "type")]
+    pub url: String,
     /// A short description of the error.
     pub title: String,
     /// A longer description of the error.
     pub detail: String,
     /// The status code.
     pub status: i64,
+}
+
+#[derive(Debug, Clone, PartialEq, Deserialize, Serialize)]
+pub struct HorizonErrorBadRequest {
+    #[serde(flatten)]
+    pub base: HorizonErrorBase,
+    pub extras: HorizonErrorBadRequestExtras,
+}
+
+#[derive(Debug, Clone, PartialEq, Deserialize, Serialize)]
+pub struct HorizonErrorBadRequestExtras {
+    pub invalid_field: String,
+    pub reason: String,
+}
+
+#[derive(Debug, Clone, PartialEq, Deserialize, Serialize)]
+pub struct HorizonErrorTransactionFailed {
+    #[serde(flatten)]
+    pub base: HorizonErrorBase,
+    pub extras: HorizonErrorTransactionFailedExtras,
+}
+
+#[derive(Debug, Clone, PartialEq, Deserialize, Serialize)]
+pub struct HorizonErrorTransactionFailedExtras {
+    pub envelope_xdr: String,
+    pub result_xdr: String,
+    pub result_codes: HorizonErrorTransactionFailedResultCodes,
+}
+
+#[derive(Debug, Clone, PartialEq, Deserialize, Serialize)]
+pub struct HorizonErrorTransactionFailedResultCodes {
+    pub transaction: String,
+    #[serde(default)]
+    pub operations: Vec<String>,
+}
+
+#[derive(Debug, Clone, PartialEq, Deserialize, Serialize)]
+pub struct HorizonErrorTransactionMalformed {
+    #[serde(flatten)]
+    pub base: HorizonErrorBase,
+    pub extras: HorizonErrorTransactionMalformedExtras,
+}
+
+#[derive(Debug, Clone, PartialEq, Deserialize, Serialize)]
+pub struct HorizonErrorTransactionMalformedExtras {
+    pub envelope_xdr: String,
+}
+
+impl<'de> serde::Deserialize<'de> for HorizonError {
+    fn deserialize<D>(de: D) -> Result<Self, D::Error>
+    where
+        D: serde::Deserializer<'de>,
+    {
+        let json_value: serde_json::Value = serde::Deserialize::deserialize(de)?;
+        let error_object = json_value
+            .as_object()
+            .ok_or(serde::de::Error::custom("expected a stellar error object"))?;
+        let error_type = error_object
+            .get("type")
+            .ok_or(serde::de::Error::custom("expected type field"))?;
+        let error_type_str = error_type.as_str().ok_or(serde::de::Error::custom(
+            "expected type field to be a string",
+        ))?;
+
+        match error_type_str {
+            BAD_REQUEST_TYPE => {
+                let horizon_error: HorizonErrorBadRequest = serde_json::from_value(json_value)
+                    .map_err(|_| serde::de::Error::custom("bad_request"))?;
+                Ok(HorizonError::BadRequest(horizon_error))
+            }
+            TRANSACTION_FAILED_TYPE => {
+                let horizon_error: HorizonErrorTransactionFailed =
+                    serde_json::from_value(json_value)
+                        .map_err(|_| serde::de::Error::custom("transaction_failed"))?;
+                Ok(HorizonError::TransactionFailed(horizon_error))
+            }
+            TRANSACTION_MALFORMED_TYPE => {
+                let horizon_error: HorizonErrorTransactionMalformed =
+                    serde_json::from_value(json_value)
+                        .map_err(|_| serde::de::Error::custom("transaction_malformed"))?;
+                Ok(HorizonError::TransactionMalformed(horizon_error))
+            }
+            BEFORE_HISTORY_TYPE => {
+                let horizon_error: HorizonErrorBase = serde_json::from_value(json_value)
+                    .map_err(|_| serde::de::Error::custom("before_history"))?;
+                Ok(HorizonError::BeforeHistory(horizon_error))
+            }
+            STALE_HISTORY_TYPE => {
+                let horizon_error: HorizonErrorBase = serde_json::from_value(json_value)
+                    .map_err(|_| serde::de::Error::custom("stale_history"))?;
+                Ok(HorizonError::StaleHistory(horizon_error))
+            }
+            TIMEOUT_TYPE => {
+                let horizon_error: HorizonErrorBase = serde_json::from_value(json_value)
+                    .map_err(|_| serde::de::Error::custom("timeout"))?;
+                Ok(HorizonError::Timeout(horizon_error))
+            }
+            _ => {
+                let horizon_error: HorizonErrorBase = serde_json::from_value(json_value)
+                    .map_err(|_| serde::de::Error::custom("bad_request"))?;
+                Ok(HorizonError::Other(horizon_error))
+            }
+        }
+    }
+}
+
+impl serde::Serialize for HorizonError {
+    fn serialize<S>(&self, ser: S) -> Result<S::Ok, S::Error>
+    where
+        S: serde::Serializer,
+    {
+        match self {
+            HorizonError::BadRequest(horizon_error) => horizon_error.serialize(ser),
+            HorizonError::TransactionFailed(horizon_error) => horizon_error.serialize(ser),
+            HorizonError::TransactionMalformed(horizon_error) => horizon_error.serialize(ser),
+            HorizonError::BeforeHistory(horizon_error) => horizon_error.serialize(ser),
+            HorizonError::StaleHistory(horizon_error) => horizon_error.serialize(ser),
+            HorizonError::Timeout(horizon_error) => horizon_error.serialize(ser),
+            HorizonError::Other(horizon_error) => horizon_error.serialize(ser),
+        }
+    }
 }

--- a/tests/fixtures/error_bad_request.json
+++ b/tests/fixtures/error_bad_request.json
@@ -1,0 +1,10 @@
+{
+  "type": "https://stellar.org/horizon-errors/bad_request",
+  "title": "Bad Request",
+  "status": 400,
+  "detail": "The request you sent was invalid in some way",
+  "extras": {
+    "invalid_field": "limit",
+    "reason": "unparseable value"
+  }
+}

--- a/tests/fixtures/error_before_history.json
+++ b/tests/fixtures/error_before_history.json
@@ -1,0 +1,6 @@
+{
+  "type": "https://stellar.org/horizon-errors/before_history",
+  "title": "Data Requested Is Before Recorded History",
+  "status": 410,
+  "detail": "This horizon instance is configured to only track a portion of the stellar network's latest history. This request is asking for results prior to the recorded history known to this horizon instance."
+}

--- a/tests/fixtures/error_invalid_accounts_params.json
+++ b/tests/fixtures/error_invalid_accounts_params.json
@@ -1,0 +1,6 @@
+{
+  "type": "https://stellar.org/horizon-errors/invalid_accounts_params",
+  "title": "Invalid Accounts Parameters",
+  "status": 400,
+  "detail": "Exactly one filter is required. Please ensure that you are including a signer, an asset, or a sponsor filter."
+}

--- a/tests/fixtures/error_invalid_order_book.json
+++ b/tests/fixtures/error_invalid_order_book.json
@@ -1,0 +1,6 @@
+{
+  "type": "https://stellar.org/horizon-errors/invalid_order_book",
+  "title": "Invalid Order Book Parameters",
+  "status": 400,
+  "detail": "The parameters that specify what order book to view are invalid in some way. Please ensure that your type parameters (selling_asset_type and buying_asset_type) are one the following valid values: native, credit_alphanum4, credit_alphanum12.  Also ensure that you have specified selling_asset_code and selling_asset_issuer if selling_asset_type is not 'native', as well as buying_asset_code and buying_asset_issuer if buying_asset_type is not 'native'"
+}

--- a/tests/fixtures/error_stale_history.json
+++ b/tests/fixtures/error_stale_history.json
@@ -1,0 +1,6 @@
+{
+  "type": "https://stellar.org/horizon-errors/stale_history",
+  "title": "Historical DB Is Too Stale",
+  "status": 503,
+  "detail": "This horizon instance is configured to reject client requests when it can determine that the history database is lagging too far behind the connected instance of stellar-core.  If you operate this server, please ensure that the ingestion system is properly running."
+}

--- a/tests/fixtures/error_timeout.json
+++ b/tests/fixtures/error_timeout.json
@@ -1,0 +1,6 @@
+{
+  "type": "https://stellar.org/horizon-errors/timeout",
+  "title": "Timeout",
+  "status": 504,
+  "detail": "Your request timed out before completing.  Please try your request again. If you are submitting a transaction make sure you are sending exactly the same transaction (with the same sequence number)."
+}

--- a/tests/fixtures/error_transaction_failed.json
+++ b/tests/fixtures/error_transaction_failed.json
@@ -1,0 +1,13 @@
+{
+  "type": "https://stellar.org/horizon-errors/transaction_failed",
+  "title": "Transaction Failed",
+  "status": 400,
+  "detail": "The transaction failed when submitted to the stellar network. The `extras.result_codes` field on this response contains further details.  Descriptions of each code can be found at: https://www.stellar.org/developers/guides/concepts/list-of-operations.html",
+  "extras": {
+    "envelope_xdr": "AAAAAgAAAADdfhHDs4Vaug6p8Oxb1QRjNRdJt3pYKKBVhFHrEgd9QAAAAAoAEi4YAAAAAwAAAAEAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAEAAAAAAAAACwAAAAAAAAAAAAAAAAAAAAESB31AAAAAQFhc/liVXbLk3NtB2BtweFJ064JdDIfrTSrqKMhb1oIRK+0PSyvjzZTkRCJmQY3bHNXYNuepa2TF7aBdibrb1gI=",
+    "result_codes": {
+      "transaction": "tx_insufficient_fee"
+    },
+    "result_xdr": "AAAAAAAAAAr////3AAAAAA=="
+  }
+}

--- a/tests/fixtures/error_transaction_malformed.json
+++ b/tests/fixtures/error_transaction_malformed.json
@@ -1,0 +1,9 @@
+{
+  "type": "https://stellar.org/horizon-errors/transaction_malformed",
+  "title": "Transaction Malformed",
+  "status": 400,
+  "detail": "Horizon could not decode the transaction envelope in this request. A transaction should be an XDR TransactionEnvelope struct encoded using base64.  The envelope read from this request is echoed in the `extras.envelope_xdr` field of this response for your convenience.",
+  "extras": {
+    "envelope_xdr": "BBBBBPORy3CoX6ox2ilbeiVjBA5WlpCSZRcjZ7VE9Wf4QVk7AAAAZAAAQz0AAAACAAAAAAAAAAAAAAABAAAAAAAAAAEAAAAA85HLcKhfqjHaKVt6JWMEDlaWkJJlFyNntUT1Z/hBWTsAAAAAAAAAAAL68IAAAAAAAAAAARN17BEAAABAA9Ad7OKc7y60NT/JuobaHOfmuq8KbZqcV6G/es94u9yT84fi0aI7tJsFMOyy8cZ4meY3Nn908OU+KfRWV40UCw=="
+  }
+}

--- a/tests/resources_test.rs
+++ b/tests/resources_test.rs
@@ -1,3 +1,4 @@
+use stellar_horizon::horizon_error::HorizonError;
 use stellar_horizon::page::Page;
 use stellar_horizon::resources::*;
 
@@ -107,3 +108,51 @@ fn test_effects_base() {
         assert!(!effect.base().paging_token.is_empty());
     }
 }
+
+impl_serde_test!(
+    test_horizon_error_bad_request,
+    HorizonError,
+    "./fixtures/error_bad_request.json"
+);
+
+impl_serde_test!(
+    test_horizon_error_transaction_failed,
+    HorizonError,
+    "./fixtures/error_transaction_failed.json"
+);
+
+impl_serde_test!(
+    test_horizon_error_transaction_malformed,
+    HorizonError,
+    "./fixtures/error_transaction_malformed.json"
+);
+
+impl_serde_test!(
+    test_horizon_error_before_history,
+    HorizonError,
+    "./fixtures/error_before_history.json"
+);
+
+impl_serde_test!(
+    test_horizon_error_stale_history,
+    HorizonError,
+    "./fixtures/error_stale_history.json"
+);
+
+impl_serde_test!(
+    test_horizon_error_timeout,
+    HorizonError,
+    "./fixtures/error_timeout.json"
+);
+
+impl_serde_test!(
+    test_horizon_error_invalid_accounts_params,
+    HorizonError,
+    "./fixtures/error_invalid_accounts_params.json"
+);
+
+impl_serde_test!(
+    test_horizon_error_invalid_order_book,
+    HorizonError,
+    "./fixtures/error_invalid_order_book.json"
+);


### PR DESCRIPTION
This is an alternative implementation of #1 that is strongly typed and supports all types of errors from horizon.