### PR TITLE
infra: Updated GitHub Actions workflow

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -10,38 +10,21 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - name: Checkout
-        uses: actions/checkout@v2
+        uses: actions/checkout@v4
 
       - name: Install stable toolchain
-        uses: actions-rs/toolchain@v1
-        with:
-          toolchain: stable
-          override: true
+        run: rustup toolchain install stable
 
-      - name: Cache cargo
-        uses: actions/cache@v1
-        id: cache
-        with:
-          path: ~/.cargo
-          key: ${{ runner.os }}-cargo-${{ hashFiles('**/Cargo.toml') }}
+      - uses: Swatinem/rust-cache@v2
 
       - name: Run cargo style check
-        uses: actions-rs/cargo@v1
-        with:
-          command: fmt
-          args: --all -- --check
+        run: cargo fmt --all -- --check
 
       - name: Run cargo test
-        uses: actions-rs/cargo@v1
-        with:
-          command: test
-          args: --lib
+        run: cargo test --lib
 
       - name: Run cargo integration test
-        uses: actions-rs/cargo@v1
-        with:
-          command: test
-          args: -- --test-threads=1
+        run: cargo test -- --test-threads=1
         if: github.ref == 'refs/heads/master'
         env:
           SECRET_SEED: ${{ secrets.SECRET_SEED }}

--- a/.github/workflows/coverage.yml
+++ b/.github/workflows/coverage.yml
@@ -11,14 +11,12 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - name: Checkout
-        uses: actions/checkout@v2
+        uses: actions/checkout@v4
 
       - name: Install stable toolchain
-        uses: actions-rs/toolchain@v1
-        with:
-          profile: minimal
-          toolchain: stable
-          override: true
+        run: rustup toolchain install stable --profile minimal
+
+      - uses: Swatinem/rust-cache@v2
 
       - uses: taiki-e/install-action@cargo-tarpaulin
 
@@ -28,6 +26,4 @@ jobs:
           SECRET_SEED: ${{ secrets.SECRET_SEED }}
 
       - name: Upload to codecov.io
-        uses: codecov/codecov-action@v1
-        with:
-          token: ${{secrets.CODECOV_TOKEN}}
+        uses: codecov/codecov-action@v5

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -9,31 +9,22 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - name: Checkout
-        uses: actions/checkout@v2
+        uses: actions/checkout@v4
 
       - name: Install stable toolchain
-        uses: actions-rs/toolchain@v1
-        with:
-          profile: minimal
-          toolchain: stable
-          override: true
+        run: rustup toolchain install stable --profile minimal
+
+      - uses: Swatinem/rust-cache@v2
 
       - name: Cargo login
-        uses: actions-rs/cargo@v1
-        with:
-          command: login
-          args: -- ${{ secrets.CARGO_TOKEN }}
+        run: echo "${{ secrets.CARGO_TOKEN }}" | cargo login
 
       - name: Cargo publish
         run: cargo publish
 
       - name: GitHub Release
-        id: create_release
-        uses: actions/create-release@v1
-        env:
-          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+        uses: softprops/action-gh-release@v2
         with:
-          tag_name: ${{ github.ref }}
-          release_name: Release ${{ github.ref }}
-          draft: false
+          name: Release ${{ github.ref_name }}
+          draft: true
           prerelease: false


### PR DESCRIPTION
* Updated `actions/checkout@v2` to `v4`.

* Updated `codecov/codecov-action@v1` to `v5` (token no longer required).

* Replaced deprecated `actions/cache@v1` with `Swatinem/rust-cache@v2`.

* Replaced unmaintained `actions-rs/...` actions with direct calls to `rustup` and `cargo`.

* Replaced deprecated `actions/create-release` with `softprops/action-gh-release`.